### PR TITLE
unsafe_assignment_fix

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -5,7 +5,7 @@ import fibonacci from "./fib";
 export default (req, res) => {
   const { num } = req.params;
 
-  const fibN = fibonacci(parseInt(num));
+  const fibN: number = fibonacci(parseInt(num));
   let result = `fibonacci(${num}) is ${fibN}`;
 
   if (fibN < 0) {


### PR DESCRIPTION
fixed the assignment error on Line 6 of fibRoute by adding the respective return value of number.